### PR TITLE
Skip subagent sessions in SessionStart hook

### DIFF
--- a/scripts/hooks.sh
+++ b/scripts/hooks.sh
@@ -47,6 +47,13 @@ INNER_PID=$(get_ppid "$PPID")
 OUTER_PID=$(get_ppid "$INNER_PID")
 TMUX_PANE_ID="${TMUX_PANE:-}"
 
+# Skip subagent processes (reparented to init after parent exits).
+# Empty OUTER_PID means ps couldn't find the ancestor (already gone), which
+# is the same signal — and `[[ "" -le 1 ]]` would abort under set -e.
+if [[ -z "$OUTER_PID" || "$OUTER_PID" -le 1 ]]; then
+  exit 0
+fi
+
 if [[ "$SOURCE" != "startup" ]] && get_cmdline "$OUTER_PID" | grep -q -- '--fork-session'; then
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Skip writing a session entry when the `SessionStart` hook is fired by an Agent-tool subagent. Subagents are detached at spawn, so by the time the hook runs the great-grandparent has been reparented to `init` (`OUTER_PID <= 1`) — that's the fingerprint we key off.
- Also handle empty `OUTER_PID` (ancestor already vanished between `ps` calls) so `[[ "" -le 1 ]]` doesn't abort the hook under `set -euo pipefail`.

This sits next to the existing `--fork-session` skip and addresses the same class of problem: keeping non-user-interactive CC processes out of the switcher popup.

Fixes #1

## Test plan

- [ ] Run `scripts/hooks.sh install` to regenerate `~/.tmux-cc/hooks/session-start.sh` from the updated heredoc.
- [ ] Start a regular `claude` session in a tmux pane → entry appears in `~/.tmux-cc/active/` and shows up in `prefix+C`.
- [ ] In that session, invoke a tool that spawns a subagent (e.g. delegate via the Agent tool) → no new entry appears in `~/.tmux-cc/active/` for the subagent, switcher stays clean.
- [ ] `/resume`-style forked sessions still skipped (existing `--fork-session` behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)