### PR TITLE
Fix forked session registration

### DIFF
--- a/scripts/hooks.sh
+++ b/scripts/hooks.sh
@@ -54,8 +54,17 @@ if [[ -z "$OUTER_PID" || "$OUTER_PID" -le 1 ]]; then
   exit 0
 fi
 
-if [[ "$SOURCE" != "startup" ]] && get_cmdline "$OUTER_PID" | grep -q -- '--fork-session'; then
-  exit 0
+# Skip --fork-session SessionStart events: CC fires SessionStart for the
+# fork using the *parent's* session_id, which would clobber the parent's
+# registry file. The hook is spawned directly by claude here, so the flag
+# lives in $PPID's argv; walk the near chain to also handle a shell-wrapper
+# variant.
+if [[ "$SOURCE" != "startup" ]]; then
+  for p in "$PPID" "$INNER_PID" "$OUTER_PID"; do
+    if [[ -n "$p" ]] && get_cmdline "$p" | grep -q -- '--fork-session'; then
+      exit 0
+    fi
+  done
 fi
 
 TMP_FILE="$ACTIVE_DIR/.${SESSION_ID}.tmp"
@@ -104,10 +113,44 @@ INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
 HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // empty')
 TARGET_FILE="$ACTIVE_DIR/${SESSION_ID}.json"
-
-[ ! -f "$TARGET_FILE" ] && exit 0
-
 NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+# Fallback registration for forked sessions. CC's fork SessionStart fires
+# with the parent's session_id (skipped in session-start.sh to avoid
+# clobbering the parent), so the fork never gets its own registry file.
+# UserPromptSubmit is the first event to carry the fork's real session_id
+# — register on first sight here so the fork shows up in the switcher.
+if [[ ! -f "$TARGET_FILE" ]]; then
+  if [[ "$HOOK_EVENT" != "UserPromptSubmit" ]]; then
+    exit 0
+  fi
+  CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+  get_ppid() { ps -o ppid= -p "$1" 2>/dev/null | tr -d ' '; }
+  INNER_PID=$(get_ppid "$PPID")
+  OUTER_PID=$(get_ppid "$INNER_PID")
+  TMUX_PANE_ID="${TMUX_PANE:-}"
+  # Same subagent guard as session-start.sh
+  if [[ -z "$OUTER_PID" || "$OUTER_PID" -le 1 ]]; then
+    exit 0
+  fi
+  TMP_FILE="$ACTIVE_DIR/.${SESSION_ID}.tmp"
+  cat > "$TMP_FILE" <<ENTRY
+{
+  "pid": $INNER_PID,
+  "innerPid": $INNER_PID,
+  "outerPid": $OUTER_PID,
+  "cwd": "$(echo "$CWD" | sed 's/"/\\"/g')",
+  "model": null,
+  "source": "fork",
+  "tmuxPane": $([ -n "$TMUX_PANE_ID" ] && echo "\"$TMUX_PANE_ID\"" || echo "null"),
+  "startedAt": "$NOW",
+  "status": "idle",
+  "statusDetail": null,
+  "statusUpdatedAt": "$NOW"
+}
+ENTRY
+  mv "$TMP_FILE" "$TARGET_FILE"
+fi
 
 case "$HOOK_EVENT" in
   Stop)


### PR DESCRIPTION
Two related bugs around `--fork-session`, both with the same root cause: CC fires the fork's `SessionStart` with the **parent's** `session_id`.

## Summary

- **`session-start.sh`** — fix the `--fork-session` skip. Previously checked `OUTER_PID`'s argv (always tmux on this platform), so it never fired and the fork's `SessionStart` was silently overwriting the parent's registry. Now walks the near chain `$PPID -> INNER_PID -> OUTER_PID`, since the flag actually lives on `$PPID` (the claude process) when the hook is spawned directly.
- **`session-status.sh`** — fallback registration. With the clobber fixed, the fork has no registry at all, because `SessionStart` never carries the fork's real id. When `UserPromptSubmit` arrives for an unknown session id, write a registry entry on the fly: `cwd` from the payload, `innerPid`/`outerPid` from the process tree, `tmuxPane` from `$TMUX_PANE`. Same subagent guard as `session-start.sh`. `model` is `null` (not in the `UserPromptSubmit` payload) — separate known issue, to be addressed later.

Fixes #3
Fixes #4

## Verified end-to-end (2026-04-25)

Real-world repro:

1. `claude` in fresh pane → got session id `fc30b410...`
2. `claude --resume fc30b410...` in same pane (Pane A, `%22`) → registry shows `innerPid: 48743`, `tmuxPane: "%22"`, `source: "resume"`. ✓
3. `claude --resume fc30b410... --fork-session` in new pane (Pane B, `%24`) → fork's real session id is `37192d2a...`.

After step 3:
- Parent's `fc30b410.json` is **untouched** — still `innerPid: 48743`, `tmuxPane: "%22"`. (Without the fix, this had been clobbered to point to the fork's pane.)
- New `37192d2a.json` exists with `innerPid: 58699`, `tmuxPane: "%24"`, `source: "fork"`. (Without the fix, this file did not exist.)
- Switcher popup shows both rows; selecting each jumps to the correct pane.

## Test plan

- [x] Fresh `claude` startup still registers normally (`source: "startup"`, model populated).
- [x] `claude --resume <id>` registers with `source: "resume"` and correct innerPid.
- [x] `claude --resume <id> --fork-session` from a different pane: parent registry intact, fork registry created with fork's real session id.
- [x] Switcher popup shows both parent and fork; preview and selection target the correct panes.
- [x] Subagent regression check: `Agent` tool subagent invocations don't create stray registry entries (the existing `OUTER_PID <= 1` guard is preserved in both code paths).