### PR TITLE
Add save-sessions.sh and restore-sessions.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,11 @@ tmux-cc.tmux          # Plugin entry point. Sourced by tmux on load. Binds prefi
 scripts/
   hooks.sh            # CLI tool (install|uninstall|status) that manages Claude Code lifecycle hooks.
   switcher.sh         # The fzf-based session switcher UI. Also serves fzf callbacks (--render, --cycle, etc).
+  save-sessions.sh    # Snapshots active CC sessions to ~/.tmux-cc/saved-sessions.json keyed by tmux positional address. Companion to tmux-resurrect.
+  restore-sessions.sh # Reads ~/.tmux-cc/saved-sessions.json and replays `claude --resume <sessionId>` into each matching tmux pane (--dry-run to preview). Companion to save-sessions.sh.
 ```
+
+See README "Save/Restore Sessions Across Reboots" for the full flow.
 
 ## Runtime data (not in repo)
 
@@ -22,6 +26,7 @@ scripts/
   active/
     {session-id}.json # One file per active session, written/updated by hooks
   tmux-cc.conf        # Display preferences (id/directory/tmux/preview/sort modes)
+  saved-sessions.json # Snapshot of active CC sessions keyed by tmux session:window.pane address, written by save-sessions.sh
 ```
 
 The hook scripts under `~/.tmux-cc/hooks/` are **generated** by `hooks.sh install` (written via heredocs in `write_hook_scripts()`). They are not checked into the repo. If you change the hook logic, edit the heredocs in `hooks.sh` and re-run `install`.
@@ -53,6 +58,10 @@ The hook scripts under `~/.tmux-cc/hooks/` are **generated** by `hooks.sh instal
    - Renders everything into fzf with live pane preview
 
 6. **switcher.sh** also handles fzf callbacks. fzf's `--bind` options invoke the same script with flags like `--cycle id`, `--cycle sort`, `--resort <tmpfile>`, `--render <tmpfile>`, `--render-header`, and `--toggle-preview`. This lets the user change display settings and sort order without leaving fzf.
+
+7. **save-sessions.sh** is orthogonal to the switcher flow. It snapshots `~/.tmux-cc/active/*.json` to `~/.tmux-cc/saved-sessions.json`, keyed by tmux positional address (`session_name:window_index.pane_index`) resolved via `tmux list-panes -aF`. Filters dead sessions with the same `kill -0` test the switcher uses. Positional addresses survive `tmux-resurrect` restore (ephemeral `%pane_id`s do not), so the restore step can match each saved CC session to its restored pane.
+
+8. **restore-sessions.sh** is the inverse: reads `~/.tmux-cc/saved-sessions.json`, looks up each saved address against the current `tmux list-panes`, and runs `claude --resume <sessionId>` in the matching pane via `tmux send-keys` (preceded by `C-u` to clear any partial prompt input). Skips entries whose pane no longer exists. Supports `--dry-run` to preview without sending keystrokes. Both scripts are still manually invoked; auto-wiring into resurrect's pre-save / post-restore hooks is tracked in #7.
 
 ## Key design decisions
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,26 @@ run '~/.tmux/plugins/tmux-cc/tmux-cc.tmux'
 
 Column visibility preferences are persisted in `~/.tmux-cc/tmux-cc.conf` and can be changed live using the keyboard shortcuts listed above.
 
+## Save/Restore Sessions Across Reboots
+
+[tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) saves and restores tmux sessions/windows/panes across reboots. It doesn't know about Claude Code, so tmux-cc ships companion scripts that pair with it.
+
+**Before reboot:**
+
+1. `prefix + Ctrl-s` — tmux-resurrect saves the tmux layout.
+2. `~/.tmux/plugins/tmux-cc/scripts/save-sessions.sh` — snapshots active CC sessions.
+
+**After reboot:**
+
+1. `prefix + Ctrl-r` — tmux-resurrect restores the tmux layout.
+2. `~/.tmux/plugins/tmux-cc/scripts/restore-sessions.sh` — replays `claude --resume <sessionId>` into each matching pane.
+
+`save-sessions.sh` writes `~/.tmux-cc/saved-sessions.json` mapping each live CC session to its tmux pane coordinates (`session:window.pane`) — coordinates that are stable across restore even though pane ids change. `restore-sessions.sh` reads the file back and runs `claude --resume <sessionId>` in the pane at each saved address.
+
+Use `restore-sessions.sh --dry-run` to preview what would be restored without sending any keystrokes.
+
+> Auto-wiring these scripts into resurrect's pre-save and post-restore hooks (so you don't have to remember the second step in each list) is tracked in [#7](https://github.com/anglee/tmux-cc/issues/7).
+
 ## How it works
 
 1. `hooks.sh install` writes three small hook scripts to `~/.tmux-cc/hooks/` and registers them in `~/.claude/settings.json`.

--- a/scripts/restore-sessions.sh
+++ b/scripts/restore-sessions.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read ~/.tmux-cc/saved-sessions.json and replay `claude --resume <sessionId>`
+# into each matching tmux pane. Companion to save-sessions.sh and
+# tmux-resurrect: invoke after `prefix + Ctrl-r` has restored the tmux layout.
+#
+# Use --dry-run to preview without sending any keystrokes.
+#
+# Idempotency: panes are skipped if their foreground process isn't a known
+# shell (bash/zsh/fish/sh/dash). This prevents typing into an already-running
+# claude on accidental re-runs, but means non-allowlisted shells (nu, xonsh,
+# etc.) won't restore — extend SHELL_ALLOWLIST if needed.
+#
+# `claude --resume` runs in whatever cwd the pane has (tmux-resurrect already
+# restores pane cwd). The saved cwd is printed for visibility only.
+#
+# See issue #7.
+
+DRY_RUN=false
+case "${1:-}" in
+  --dry-run) DRY_RUN=true ;;
+  "") ;;
+  -h|--help) echo "Usage: $(basename "$0") [--dry-run]"; exit 0 ;;
+  *) echo "Usage: $(basename "$0") [--dry-run]" >&2; exit 1 ;;
+esac
+
+SAVED_FILE="$HOME/.tmux-cc/saved-sessions.json"
+
+if [[ ! -f "$SAVED_FILE" ]]; then
+  echo "No saved sessions file at $SAVED_FILE. Run save-sessions.sh first." >&2
+  exit 1
+fi
+
+if ! jq -e . "$SAVED_FILE" >/dev/null 2>&1; then
+  echo "Saved file is malformed JSON: $SAVED_FILE" >&2
+  exit 1
+fi
+
+PANE_LIST=$(mktemp /tmp/tmux-cc-restore-panes.XXXXXX)
+trap 'rm -f "$PANE_LIST"' EXIT
+tmux list-panes -aF $'#{session_name}:#{window_index}.#{pane_index}\t#{pane_current_command}' \
+  > "$PANE_LIST" 2>/dev/null || true
+
+if [[ ! -s "$PANE_LIST" ]]; then
+  echo "Warning: no tmux panes found (is the tmux server running?)." >&2
+fi
+
+prefix=""
+if $DRY_RUN; then prefix="[dry-run] "; fi
+
+# Foreground processes that indicate "pane is at a shell prompt, safe to type".
+SHELL_ALLOWLIST_RE='^(bash|zsh|fish|sh|dash)$'
+
+total=0
+restored=0
+skipped=0
+
+while IFS=$'\t' read -r addr sid cwd; do
+  [[ -n "$addr" ]] || continue
+  total=$((total + 1))
+
+  pane_cmd=$(awk -F'\t' -v a="$addr" '$1 == a { print $2; exit }' "$PANE_LIST")
+
+  if [[ -z "$pane_cmd" ]]; then
+    echo "${prefix}${addr} -> SKIP (no such pane)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if ! [[ "$pane_cmd" =~ $SHELL_ALLOWLIST_RE ]]; then
+    echo "${prefix}${addr} -> SKIP (not at shell prompt: $pane_cmd)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  cmd="claude --resume $sid"
+  echo "${prefix}${addr} -> ${cmd}    (cwd: ${cwd})"
+
+  if ! $DRY_RUN; then
+    # C-u first to clear any partial input at the prompt. Any send-keys
+    # failure (e.g. pane vanished between list-panes and now) is per-pane,
+    # so we log and continue rather than abort the whole restore.
+    if ! tmux send-keys -t "$addr" C-u 2>/dev/null \
+       || ! tmux send-keys -t "$addr" "$cmd" Enter 2>/dev/null; then
+      echo "${prefix}${addr} -> SKIP (send-keys failed)"
+      skipped=$((skipped + 1))
+      continue
+    fi
+  fi
+
+  restored=$((restored + 1))
+done < <(jq -r '(.panes // {}) | to_entries[] | [.key, .value.sessionId, (.value.cwd // "<unknown>")] | @tsv' "$SAVED_FILE")
+
+verb="Restored"
+if $DRY_RUN; then verb="Would restore"; fi
+
+echo "${prefix}${verb} ${restored} of ${total} session(s); ${skipped} skipped."

--- a/scripts/save-sessions.sh
+++ b/scripts/save-sessions.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Snapshot the currently active CC sessions to ~/.tmux-cc/saved-sessions.json,
+# keyed by stable tmux positional address (session_name:window_index.pane_index)
+# so that a later restore step can replay `claude --resume <id>` into the
+# matching panes after tmux-resurrect re-creates the layout.
+#
+# See issue #7.
+
+ACTIVE_DIR="$HOME/.tmux-cc/active"
+TARGET_FILE="$HOME/.tmux-cc/saved-sessions.json"
+mkdir -p "$(dirname "$TARGET_FILE")"
+
+TMP_ACC=$(mktemp /tmp/tmux-cc-save.XXXXXX)
+PANE_MAP=$(mktemp /tmp/tmux-cc-panes.XXXXXX)
+trap 'rm -f "$TMP_ACC" "$TMP_ACC.new" "$PANE_MAP" "$TARGET_FILE.tmp"' EXIT
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+# Build a lookup from "%pane_id" -> "session:window.pane" for every pane on
+# this tmux server. -a covers all sessions, including detached. Tab-separated
+# so session names containing spaces don't break the awk lookup below.
+tmux list-panes -aF $'#{pane_id}\t#{session_name}:#{window_index}.#{pane_index}' \
+  > "$PANE_MAP" 2>/dev/null || true
+
+if [[ ! -s "$PANE_MAP" ]]; then
+  echo "Warning: no tmux panes found (is the tmux server running?)." >&2
+fi
+
+echo '{}' > "$TMP_ACC"
+count=0
+skipped_non_tmux=0
+
+shopt -s nullglob
+for f in "$ACTIVE_DIR"/*.json; do
+  inner_pid=$(jq -r '.innerPid // .pid // 0' "$f")
+  [[ "$inner_pid" -gt 0 ]] || continue
+  kill -0 "$inner_pid" 2>/dev/null || continue
+
+  pane_id=$(jq -r '.tmuxPane // ""' "$f")
+  if [[ -z "$pane_id" ]]; then
+    skipped_non_tmux=$((skipped_non_tmux + 1))
+    continue
+  fi
+
+  addr=$(awk -F'\t' -v p="$pane_id" '$1 == p { print $2; exit }' "$PANE_MAP")
+  [[ -n "$addr" ]] || continue
+
+  sid=$(basename "$f" .json)
+
+  # Collision tiebreak: if two alive registries resolve to the same addr
+  # (e.g. parent + fork briefly overlapping in the same pane), last write
+  # wins in glob order (alphabetical by session_id). Acceptable for phase 1;
+  # follow-up may sort by statusUpdatedAt for determinism.
+  jq --arg addr "$addr" \
+     --arg sid "$sid" \
+     --slurpfile reg "$f" \
+     '. + { ($addr): { sessionId: $sid, cwd: $reg[0].cwd, model: $reg[0].model } }' \
+     "$TMP_ACC" > "$TMP_ACC.new"
+  mv "$TMP_ACC.new" "$TMP_ACC"
+
+  count=$((count + 1))
+done
+shopt -u nullglob
+
+jq --arg now "$NOW" '{ savedAt: $now, panes: . }' "$TMP_ACC" > "$TARGET_FILE.tmp"
+# Defensive re-parse: the prior jq already produced valid JSON by construction,
+# so this catches only post-write corruption (disk hiccup, etc.) before we
+# overwrite the durable target. Intentional belt-and-suspenders — keep.
+jq -e . "$TARGET_FILE.tmp" >/dev/null
+mv "$TARGET_FILE.tmp" "$TARGET_FILE"
+
+if [[ "$skipped_non_tmux" -gt 0 ]]; then
+  echo "Saved $count CC session(s) (skipped $skipped_non_tmux non-tmux) to $TARGET_FILE"
+else
+  echo "Saved $count CC session(s) to $TARGET_FILE"
+fi


### PR DESCRIPTION
Companion scripts for `tmux-resurrect` so CC sessions can be saved and replayed across reboots. Tracks #7.

## Flow

**Before reboot** (saving):

1. `prefix + Ctrl-s` — tmux-resurrect saves layout.
2. `scripts/save-sessions.sh` — writes `~/.tmux-cc/saved-sessions.json` mapping each live CC session to its tmux positional address (`session:window.pane`).

**After reboot** (restoring):

1. `prefix + Ctrl-r` — tmux-resurrect restores layout.
2. `scripts/restore-sessions.sh` — reads `saved-sessions.json` and runs `claude --resume <sessionId>` in each matching pane via `tmux send-keys` (preceded by `C-u` to clear any partial input).

`restore-sessions.sh --dry-run` previews without sending keystrokes.

## save-sessions.sh

For each `~/.tmux-cc/active/*.json`:

1. Skip if `kill -0 $innerPid` fails (same liveness filter the switcher uses at `switcher.sh:280`).
2. If `tmuxPane: null` (CC outside tmux), skip and count separately for diagnostics.
3. Resolve the registry's ephemeral `tmuxPane` (`%pane_id`) to a positional address via `tmux list-panes -aF '#{pane_id} #{session_name}:#{window_index}.#{pane_index}'`.
4. Emit an entry under that address with `sessionId`, `cwd`, `model`.

Wraps with a `savedAt` timestamp:

```json
{
  "savedAt": "2026-04-25T16:56:21.000Z",
  "panes": {
    "main:1.2": {
      "sessionId": "abc-...",
      "cwd": "/path",
      "model": "claude-opus-4-7[1m]"
    }
  }
}
```

Atomic write: builds the JSON in a temp file, validates with `jq -e .`, then `mv` to target. `mkdir -p` ensures the target directory exists. Warns to stderr if `tmux list-panes` returns nothing.

## restore-sessions.sh

For each entry in `saved-sessions.json`:

1. Validate the saved file parses with `jq -e .` (errors out cleanly on malformed JSON).
2. If the saved address no longer exists in `tmux list-panes`, log `SKIP (no such pane)` and move on.
3. **Idempotency guard**: if the pane's foreground process isn't an allowlisted shell (`bash`/`zsh`/`fish`/`sh`/`dash`), log `SKIP (not at shell prompt: <cmd>)` and move on. Prevents typing `claude --resume` into an already-running CC on accidental re-runs.
4. Send `C-u` to clear any partial input, then `claude --resume <sessionId>` + `Enter`. Per-pane `send-keys` failure is non-fatal — logged as `SKIP (send-keys failed)` so the rest of the restore proceeds.

`--dry-run` prints what would happen and exits without sending any keys.

Output examples:

```
0:1.2 -> claude --resume abc-...    (cwd: /path)
0:2.0 -> SKIP (no such pane)
0:3.1 -> SKIP (not at shell prompt: node)
Restored 1 of 3 session(s); 2 skipped.
```

`claude --resume` runs in whatever cwd the pane has (tmux-resurrect already restores pane cwd); the saved cwd is shown for visibility only.

## Why a positional key, not pane id

`%pane_id` is ephemeral — `tmux-resurrect` creates fresh ones on restore. `(session_name, window_index, pane_index)` is what survives the round-trip.

## Why save model

Costs nothing, and once #6 (resumed/forked sessions show `null` model) is fixed, retroactively useful in older snapshots. Restore side currently doesn't consume `model` directly, but it'll matter when wiring into a launcher that wants to pass `--model` explicitly.

## Out of scope (follow-up)

- Auto-wiring `save-sessions.sh` into resurrect's `@resurrect-hook-pre-save-all` and `restore-sessions.sh` into the post-restore hook so the second step in each list happens automatically (#7).
- Single-jq-pass refactor of `save-sessions.sh` and per-file atomic snapshot — see #10.

## Test plan

**save-sessions.sh:**

- [x] Multi-pane setup; output keys match `tmux list-panes -aF '#{session_name}:#{window_index}.#{pane_index}'`.
- [x] `kill -0` filter: mangle a registry's `innerPid` to `999999`, re-run, confirm entry filtered out.
- [x] Restore mangled registry; entry returns.
- [x] Empty case: `Saved 0`, output is `{"savedAt": "...", "panes": {}}`.
- [x] Idempotency: two consecutive saves produce different `savedAt`, identical `panes`.
- [x] Non-tmux registry (`tmuxPane: null`): skipped with "(skipped N non-tmux)".

**restore-sessions.sh (all `--dry-run` for safety):**

- [x] Standard listing: address → claude command + cwd, no keystrokes sent.
- [x] Idempotency guard: panes already running CC are SKIPped with "not at shell prompt: <cmd>".
- [x] Stale entry: saved address that doesn't exist in current tmux → "SKIP (no such pane)".
- [x] Empty `panes: {}` → "Would restore 0 of 0; 0 skipped".
- [x] Malformed JSON: exits 1 with clear error.
- [ ] **(manual, post-merge)** Real restore inside a fresh post-resurrect-restore tmux: `prefix + Ctrl-r`, then `restore-sessions.sh`, confirm CC starts in each saved pane.

Refs #7