### PR TITLE
Ignore local-machine noise (.DS_Store, .idea/, .claude/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# macOS
+.DS_Store
+
+# Editor / IDE
+.idea/
+
+# Claude Code project-local state
+.claude/


### PR DESCRIPTION
Add a `.gitignore` so untracked local-machine files stop surfacing in `git status` / PR creation warnings.

Patterns:

- `.DS_Store` (bare — matches at any depth, so it also covers `scripts/.DS_Store`)
- `.idea/` — JetBrains IDE config
- `.claude/` — Claude Code project-local state

## Test plan

- [x] After applying, `git status` is clean (only `.gitignore` itself was newly tracked).
- [x] Future `gh pr create` runs no longer print "Warning: N uncommitted changes" from these files.