### PR TITLE
Add PermissionRequest hook for VS Code waiting status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The hook scripts under `~/.tmux-cc/hooks/` are **generated** by `hooks.sh instal
 
 1. **hooks.sh install** does two things:
    - Writes the three hook shell scripts to `~/.tmux-cc/hooks/`
-   - Adds entries to `~/.claude/settings.json` under `.hooks` for events: `SessionStart`, `SessionEnd`, `Stop`, `UserPromptSubmit`, `PostToolUse`, `Notification`
+   - Adds entries to `~/.claude/settings.json` under `.hooks` for events: `SessionStart`, `SessionEnd`, `Stop`, `UserPromptSubmit`, `PostToolUse`, `Notification`, `PermissionRequest`
 
 2. **Claude Code** calls these hooks during its lifecycle. Each hook receives JSON on stdin with fields like `session_id`, `cwd`, `model`, `hook_event_name`, etc.
 
@@ -45,6 +45,7 @@ The hook scripts under `~/.tmux-cc/hooks/` are **generated** by `hooks.sh instal
    - `Stop` -> idle
    - `UserPromptSubmit`, `PostToolUse` -> working
    - `Notification` -> idle (if idle_prompt) or waiting (otherwise)
+   - `PermissionRequest` -> waiting (covers VS Code, where `Notification(permission_prompt)` does not fire; also covers `AskUserQuestion`, which CC routes through the permission flow)
 
    It updates the JSON file in-place using jq.
 

--- a/scripts/hooks.sh
+++ b/scripts/hooks.sh
@@ -166,6 +166,9 @@ case "$HOOK_EVENT" in
       *) STATUS="waiting"; DETAIL="\"$NOTIF_TYPE\"" ;;
     esac
     ;;
+  PermissionRequest)
+    STATUS="waiting"; DETAIL="\"permission_request\""
+    ;;
   *)
     exit 0
     ;;
@@ -202,7 +205,8 @@ install_settings() {
     add_if_missing("Stop"; $status; "") |
     add_if_missing("UserPromptSubmit"; $status; "") |
     add_if_missing("PostToolUse"; $status; "") |
-    add_if_missing("Notification"; $status; "")
+    add_if_missing("Notification"; $status; "") |
+    add_if_missing("PermissionRequest"; $status; "")
   ' "$SETTINGS_FILE" > "$tmp" && mv "$tmp" "$SETTINGS_FILE"
 }
 
@@ -230,6 +234,7 @@ uninstall_settings() {
       clean("UserPromptSubmit"; $status) |
       clean("PostToolUse"; $status) |
       clean("Notification"; $status) |
+      clean("PermissionRequest"; $status) |
       if (.hooks | length) == 0 then del(.hooks) else . end
     else . end
   ' "$SETTINGS_FILE" > "$tmp" && mv "$tmp" "$SETTINGS_FILE"
@@ -249,7 +254,8 @@ check_status() {
     has_cmd("Stop"; $status) and
     has_cmd("UserPromptSubmit"; $status) and
     has_cmd("PostToolUse"; $status) and
-    has_cmd("Notification"; $status)
+    has_cmd("Notification"; $status) and
+    has_cmd("PermissionRequest"; $status)
   ' "$SETTINGS_FILE" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
Closes #11.

VS Code's CC plugin doesn't fire `Notification(permission_prompt)` when a permission dialog appears — only `PermissionRequest` does. Our `session-status.sh` only listened for `Notification`, so VS Code sessions stayed at `working` instead of transitioning to `waiting` when a Bash/Edit/Write permission prompt or `AskUserQuestion` was open. The switcher gave no signal that input was needed.

## Fix

Subscribe to `PermissionRequest` with empty matcher (matches all tools); map it to `status="waiting"` with `statusDetail="permission_request"`. Touches four spots in `scripts/hooks.sh`:

- The `session-status.sh` heredoc — new `case` arm.
- `install_settings()` — register the hook in `~/.claude/settings.json`.
- `uninstall_settings()` — corresponding cleanup.
- `check_status()` — included in the "all hooks present" check.

Plus two small CLAUDE.md updates (event list and status mappings).

## Empirically verified matrix

Spied on hook events in both environments earlier this session:

| Trigger | Terminal | VS Code |
|---|---|---|
| Bash / Edit / Write permission | `PermissionRequest` + `Notification(permission_prompt)` | `PermissionRequest` only |
| `AskUserQuestion` | `PreToolUse(AskUserQuestion)` + `PermissionRequest(AskUserQuestion)` + `Notification(permission_prompt)` | `PreToolUse(AskUserQuestion)` + `PermissionRequest(AskUserQuestion)` only |

Conclusion: a single `PermissionRequest` registration with empty matcher covers both flows in both environments. `AskUserQuestion` is internally a permission flow, so no separate `PreToolUse(AskUserQuestion)` hook is needed.

## Existing installs

`check_status` now requires `PermissionRequest`, so existing installs will report `disabled` via `hooks.sh status` until re-installed. Intentional — nudges users to re-run `install` so the new hook gets registered for their running CC sessions.

## Test plan

- [x] `bash scripts/hooks.sh install` then `bash scripts/hooks.sh status` → `enabled`.
- [x] `jq '.hooks.PermissionRequest' ~/.claude/settings.json` shows the new entry.
- [x] `grep -A1 PermissionRequest ~/.tmux-cc/hooks/session-status.sh` shows the new arm.
- [x] **Manual, VS Code (the actual bug)**: fresh VS Code CC session triggered Bash permission. Registry transitioned `status: "working"` → `"waiting"` with `statusDetail: "permission_request"` while dialog was open, then back to `"idle"` after approve + Stop. Switcher correctly showed the session under ◐ waiting during the prompt.
- [x] **Manual, terminal (sanity)**: fresh terminal CC, same Bash-permission scenario, registry transitioned to `status: "waiting"` (with `statusDetail: "permission_prompt"` — both events fire and `Notification` arrives second, overwriting the detail; `status` stays `waiting` either way), then back to `idle` after approve + Stop.

## Out of scope (follow-ups if symptoms appear)

- `PermissionDenied` event — not exercised in the spy test (always approved/answered, never denied). Cheap to add later if symptoms surface.
- MCP-server elicitations — likely use `Elicitation` and/or `Notification(elicitation_dialog)`, not exercised.
- VS Code `model: null` on `SessionStart` (not specific to this PR; observed during testing — VS Code plugin doesn't pass `model` in the startup payload). Recorded as a comment on #6.