### PR TITLE
Sync docs with recent PR changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ The hook scripts under `~/.tmux-cc/hooks/` are **generated** by `hooks.sh instal
 
 2. **Claude Code** calls these hooks during its lifecycle. Each hook receives JSON on stdin with fields like `session_id`, `cwd`, `model`, `hook_event_name`, etc.
 
-3. **session-start.sh** walks up the process tree via `ps -o ppid=` to find the Claude Code PID. It writes a JSON file to `~/.tmux-cc/active/{session_id}.json` containing pid, cwd, model, tmux pane ID, status, and timestamps. It skips forked sessions (detected via `--fork-session` in the parent cmdline).
+3. **session-start.sh** walks up the process tree via `ps -o ppid=` to find the Claude Code PID. It writes a JSON file to `~/.tmux-cc/active/{session_id}.json` containing pid, cwd, model, tmux pane ID, `entrypoint` (`$CLAUDE_CODE_ENTRYPOINT`, e.g. `cli` / `claude-vscode`), `termProgram` (`$TERM_PROGRAM`, e.g. `tmux` / `iTerm.app`), status, and timestamps. It skips forked sessions (detected by walking the near process chain `$PPID → INNER_PID → OUTER_PID` for `--fork-session` in argv) and subagents (detected via `OUTER_PID <= 1`, since they are reparented to init). The fork's *real* `session_id` is registered later via the fork-fallback path in `session-status.sh` (see step 4).
 
 4. **session-status.sh** maps hook events to statuses:
    - `Stop` -> idle
@@ -47,7 +47,7 @@ The hook scripts under `~/.tmux-cc/hooks/` are **generated** by `hooks.sh instal
    - `Notification` -> idle (if idle_prompt) or waiting (otherwise)
    - `PermissionRequest` -> waiting (covers VS Code, where `Notification(permission_prompt)` does not fire; also covers `AskUserQuestion`, which CC routes through the permission flow)
 
-   It updates the JSON file in-place using jq.
+   It updates the JSON file in-place using jq. **Fork-fallback registration**: if a hook fires for a `session_id` with no existing registry file, `session-status.sh` writes one on the fly (using the same process-tree walk and env capture as `session-start.sh`). This is how forked sessions enter the registry — CC sends the fork's real `session_id` only on `UserPromptSubmit`/later events, not on the fork's `SessionStart` (which carries the *parent's* id and is filtered out at start time).
 
 5. **switcher.sh** is the UI. It:
    - Reads all `~/.tmux-cc/active/*.json` files

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A tmux plugin for managing multiple [Claude Code](https://docs.anthropic.com/en/
 - **Last message preview** -- optionally show a snippet of Claude's most recent response
 - **Sortable** -- toggle between recent-activity and alphabetical sort with `ctrl-s`
 - **Configurable columns** -- toggle display of session ID, directory, tmux location, and message preview with keyboard shortcuts
+- **Environment-aware** -- non-tmux sessions (VS Code, plain iTerm2 / Terminal) show their environment label (`vscode`, `iTerm.app`, etc.) instead of a generic "(no pane)"
 
 ## Prerequisites
 


### PR DESCRIPTION
Three small doc updates that drifted out of sync with code changes from #5, #11, and #14.

## Changes

**`CLAUDE.md` item 3** (session-start.sh description):
- Added `entrypoint` and `termProgram` to the list of fields written to the registry (introduced in #14).
- Updated fork detection wording — was "detected via `--fork-session` in the parent cmdline"; actually walks the near process chain `$PPID → INNER_PID → OUTER_PID` since #5.
- Mentioned the subagent skip (`OUTER_PID <= 1`) added in #2.
- Cross-reference to step 4 for fork-fallback registration.

**`CLAUDE.md` item 4** (session-status.sh):
- Added a "Fork-fallback registration" paragraph documenting the load-bearing PR #5 mechanism: forks only enter the registry via `session-status.sh` writing on first hook event, since CC's `SessionStart` for the fork carries the *parent's* `session_id` and is filtered out at start time.

**`README.md`** features list:
- One new bullet: "Environment-aware — non-tmux sessions show their environment label (`vscode`, `iTerm.app`, etc.) instead of a generic '(no pane)'." Reflects the user-visible feature shipped in #14.

## Test plan

- [x] `git diff` reviewed — three line additions, no functional changes, no dead links.